### PR TITLE
Make StarDist2D macro-recordable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.project
 /.settings/
 /target/
+/.idea/
+*.iml

--- a/src/main/java/de/csbdresden/stardist/StarDist2D.java
+++ b/src/main/java/de/csbdresden/stardist/StarDist2D.java
@@ -16,6 +16,7 @@ import java.util.stream.IntStream;
 
 import javax.swing.JOptionPane;
 
+import ij.plugin.frame.Recorder;
 import org.scijava.ItemIO;
 import org.scijava.ItemVisibility;
 import org.scijava.command.Command;
@@ -200,6 +201,7 @@ public class StarDist2D extends StarDist2DBase implements Command {
 
     @Override
     public void run() {
+        record();
         checkForCSBDeep();
         if (!checkInputs()) return;
         
@@ -314,7 +316,39 @@ public class StarDist2D extends StarDist2DBase implements Command {
             }
         }
     }
-    
+
+    private void record() {
+         if (Recorder.getInstance() == null) {
+                return;
+         }
+
+         // prevent recording of run("Star Dist 2D");
+         Recorder.setCommand(null);
+
+         // record by hand
+         Recorder.recordString("run(\"" +
+                 "StarDist 2D (from Macro)" +
+                 "\", \"" +
+                 "input=[" + IJ.getImage().getTitle() + "] " +
+                 "modelChoice=[" + modelChoice + "] " +
+                 "modelFile=[" + modelFile + "] " +
+                 "modelUrl=[" + modelUrl + "] " +
+                 (normalizeInput?"normalizeinput ":"") +
+                 "percentileBottom=" + percentileBottom + " " +
+                 "percentileTop=" + percentileTop + " " +
+                 "probThresh=" + probThresh + " " +
+                 "nmsThresh=" + nmsThresh + " " +
+                 "outputType=" + outputType + " " +
+                 "nTiles=" + nTiles + " " +
+                 "excludeBoundary=" + excludeBoundary + " " +
+                 (verbose?"verbose ":"") +
+                 (showCsbdeepProgress?"showcsbdeepprogress ":"") +
+                 (showProbAndDist?"showprobanddist ":"") +
+                 "\");\n"
+         );
+
+    }
+
     // this function is very cumbersome... is there a better way to do this?
     private Pair<Dataset, Dataset> splitPrediction(final Dataset prediction) {
         final RandomAccessibleInterval<FloatType> predictionRAI = (RandomAccessibleInterval<FloatType>) prediction.getImgPlus();

--- a/src/main/java/de/csbdresden/stardist/StarDist2DFromMacro.java
+++ b/src/main/java/de/csbdresden/stardist/StarDist2DFromMacro.java
@@ -1,0 +1,200 @@
+package de.csbdresden.stardist;
+
+import ij.ImagePlus;
+import ij.gui.GenericDialog;
+import ij.plugin.filter.PlugInFilter;
+import ij.process.ImageProcessor;
+import net.imagej.Data;
+import net.imagej.Dataset;
+import net.imagej.ImageJ;
+import org.ojalgo.series.primitive.DataSeries;
+import org.scijava.ItemIO;
+import org.scijava.ItemVisibility;
+import org.scijava.command.Command;
+import org.scijava.command.CommandModule;
+import org.scijava.command.CommandService;
+import org.scijava.menu.MenuConstants;
+import org.scijava.plugin.Menu;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.ui.UIService;
+import org.scijava.widget.Button;
+import org.scijava.widget.ChoiceWidget;
+import org.scijava.widget.NumberWidget;
+
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static de.csbdresden.stardist.StarDist2DModel.MODEL_DSB2018_HEAVY_AUGMENTATION;
+import static de.csbdresden.stardist.StarDist2DModel.MODEL_DSB2018_PAPER;
+import static org.apache.log4j.helpers.Loader.getResource;
+
+/**
+ * This class serves calls from the ImageJ Macro language. It's just a mediator which calls the real StartDist2D plugin.
+ *
+ * @author: haesleinhuepf
+ * March 2020
+ */
+@Plugin(type = Command.class, menu = {
+        @org.scijava.plugin.Menu(label = MenuConstants.PLUGINS_LABEL, weight = MenuConstants.PLUGINS_WEIGHT, mnemonic = MenuConstants.PLUGINS_MNEMONIC),
+        @org.scijava.plugin.Menu(label = "StarDist"),
+        @org.scijava.plugin.Menu(label = "Other"),
+        @Menu(label = "StarDist 2D (from Macro)", weight = 2)})
+public class StarDist2DFromMacro implements Command {
+
+    @Parameter
+    private CommandService commandService;
+
+    @Parameter
+    private UIService uiService;
+
+    @Parameter
+    private Dataset input;
+
+/* // It really doesn't work with scijava dialogs :-(
+    @Parameter
+    private String modelChoice = (String) Opt.getDefault(Opt.MODEL);
+
+    @Parameter
+    private boolean normalizeInput = (boolean) Opt.getDefault(Opt.NORMALIZE_IMAGE);
+
+    @Parameter
+    private double percentileBottom = (double) Opt.getDefault(Opt.PERCENTILE_LOW);
+
+    @Parameter
+    private double percentileTop = (double) Opt.getDefault(Opt.PERCENTILE_HIGH);
+
+    @Parameter
+    private double probThresh = (double) Opt.getDefault(Opt.PROB_THRESH);
+
+    @Parameter
+    private double nmsThresh = (double) Opt.getDefault(Opt.NMS_THRESH);
+
+    @Parameter
+    private String outputType = (String) Opt.getDefault(Opt.OUTPUT_TYPE);
+
+    @Parameter(required=false)
+    private String modelFile = "";
+
+    @Parameter(required=false)
+    protected String modelUrl = "";
+
+    @Parameter
+    private int nTiles = (int) Opt.getDefault(Opt.NUM_TILES);
+
+    @Parameter
+    private int excludeBoundary = (int) Opt.getDefault(Opt.EXCLUDE_BNDRY);
+
+    @Parameter
+    private boolean verbose = (boolean) Opt.getDefault(Opt.VERBOSE);
+
+    @Parameter
+    private boolean showCsbdeepProgress = (boolean) Opt.getDefault(Opt.CSBDEEP_PROGRESS_WINDOW);
+
+    @Parameter
+    private boolean showProbAndDist = (boolean) Opt.getDefault(Opt.SHOW_PROB_DIST);
+*/
+
+
+    @Override
+    public void run() {
+        // Build an ImageJ1 generic dialog
+        String modelChoice = (String) Opt.getDefault(Opt.MODEL);
+        boolean normalizeInput = (boolean) Opt.getDefault(Opt.NORMALIZE_IMAGE);
+        double percentileBottom = (double) Opt.getDefault(Opt.PERCENTILE_LOW);
+        double percentileTop = (double) Opt.getDefault(Opt.PERCENTILE_HIGH);
+        double probThresh = (double) Opt.getDefault(Opt.PROB_THRESH);
+        double nmsThresh = (double) Opt.getDefault(Opt.NMS_THRESH);
+        String outputType = (String) Opt.getDefault(Opt.OUTPUT_TYPE);
+        String modelFile = "";
+        String modelUrl = "";
+        int nTiles = (int) Opt.getDefault(Opt.NUM_TILES);
+        int excludeBoundary = (int) Opt.getDefault(Opt.EXCLUDE_BNDRY);
+        boolean verbose = (boolean) Opt.getDefault(Opt.VERBOSE);
+        boolean showCsbdeepProgress = (boolean) Opt.getDefault(Opt.CSBDEEP_PROGRESS_WINDOW);
+        boolean showProbAndDist = (boolean) Opt.getDefault(Opt.SHOW_PROB_DIST);
+
+        GenericDialog gd = new GenericDialog("StarDist2D (From Macro)");
+        gd.addMessage("This plugin is thought for being called via ImageJ scripting only. Use 'StarDist 2D' instead.");
+
+        gd.addStringField("modelChoice", modelChoice);
+        gd.addCheckbox("normalizeInput", normalizeInput);
+        gd.addNumericField("percentileBottom", percentileBottom, 3);
+        gd.addNumericField("percentileTop", percentileTop, 3);
+        gd.addNumericField("probThresh", probThresh, 3);
+        gd.addNumericField("nmsThresh", nmsThresh, 3);
+        gd.addStringField("outputType", outputType);
+        gd.addStringField("modelFile", modelFile);
+        gd.addStringField("modelUrl", modelUrl);
+        gd.addNumericField("nTiles", nTiles, 0);
+        gd.addNumericField("excludeBoundary", excludeBoundary, 0);
+        gd.addCheckbox("verbose", verbose);
+        gd.addCheckbox("showCsbdeepProgress", showCsbdeepProgress);
+        gd.addCheckbox("showProbAndDist", showProbAndDist);
+
+        gd.showDialog();
+
+        if (gd.wasCanceled()) {
+            return;
+        }
+
+        modelChoice = gd.getNextString();
+        normalizeInput = gd.getNextBoolean();
+        percentileBottom = gd.getNextNumber();
+        percentileTop = gd.getNextNumber();
+        probThresh = gd.getNextNumber();
+        nmsThresh =  gd.getNextNumber();
+        outputType = gd.getNextString();
+        modelFile = gd.getNextString();
+        modelUrl = gd.getNextString();
+        nTiles = (int)gd.getNextNumber();
+        excludeBoundary = (int)gd.getNextNumber();
+        verbose = gd.getNextBoolean();
+        showCsbdeepProgress = gd.getNextBoolean();
+        showProbAndDist = gd.getNextBoolean();
+
+        System.out.println("normalizeInput was "+ normalizeInput);
+
+        Future module = commandService.run(StarDist2D.class, false,
+                "input", input,
+                "modelChoice", modelChoice,
+                "modelFile", (modelFile!=null?new File(modelFile):""),
+                "modelUrl",  (modelUrl!=null?modelUrl:""),
+                "normalizeInput", new Boolean(normalizeInput),
+                "percentileBottom", percentileBottom,
+                "percentileTop", percentileTop,
+                "probThresh", probThresh,
+                "nmsThresh", nmsThresh,
+                "outputType", outputType,
+                "nTiles", nTiles,
+                "excludeBoundary", excludeBoundary,
+                "verbose", verbose,
+                "showCsbdeepProgress", showCsbdeepProgress,
+                "showProbAndDist", showProbAndDist
+        );
+
+        CommandModule res = null;
+
+        try {
+            res = (CommandModule) module.get();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        } catch (ExecutionException e) {
+            e.printStackTrace();
+        }
+
+        System.out.println("RES: " + res.toString());
+        System.out.println("RES class: " + res.getClass());
+
+        Dataset label = (Dataset) res.getOutput("label");
+        uiService.show(label);
+    }
+}


### PR DESCRIPTION
Hi @uschmidt83,

there you go. As discussed [here](https://github.com/mpicbg-csbd/stardist-imagej/issues/4) and [here](https://forum.image.sc/t/automation-of-stardist-in-imagej-macros/35611/2), this brings some custom macro-recording and another plugin (a bit hidden in the menu) which serves as mediator. It calls the actual StarDist2D plugin.

The macro recorder now records things like this, which are also executable:
```
open("/PATH/TO/IMAGES/BBBC008_v1_images/human_ht29_colon_cancer_2_images/AS_09125_050116000001_A24f00d0_slice1_channel1.tif");
run("StarDist 2D (from Macro)", "input=[AS_09125_050116000001_A24f00d0_slice1_channel1.tif] modelChoice=[Versatile (fluorescent nuclei)] modelFile=[null] modelUrl=[null] normalizeinput percentileBottom=1.0 percentileTop=99.8 probThresh=0.01 nmsThresh=0.4 outputType=Both nTiles=1 excludeBoundary=2 ");
selectWindow("Label Image");
```

I assume the missing macro-recordability and -callability is a bug in ImageJ2s way of building dialogs. As soon as this bug is fixed, we can revert this commit here.

If there are any issues with this plugin, feel free to tag/ping me. I'm happy to support/maintain this part.

Cheers,
Robert
