### PR TITLE
Make StarDist (and other problematic IJ2 plugins) accessible from IJ1 Macro

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,5 +134,17 @@
 			<artifactId>csbdeep</artifactId>
 			<version>0.3.5-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/de/csbdresden/CommandFromMacro.java
+++ b/src/main/java/de/csbdresden/CommandFromMacro.java
@@ -1,0 +1,203 @@
+package de.csbdresden;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.commons.lang3.ClassUtils;
+import org.apache.commons.text.StringEscapeUtils;
+import org.scijava.ItemVisibility;
+import org.scijava.Named;
+import org.scijava.command.Command;
+import org.scijava.command.CommandInfo;
+import org.scijava.command.CommandModule;
+import org.scijava.command.CommandService;
+import org.scijava.log.LogService;
+import org.scijava.module.ModuleItem;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.service.Service;
+import org.scijava.ui.UIService;
+
+import com.google.gson.Gson;
+
+import de.csbdresden.stardist.StarDist2D;
+import ij.IJ;
+import ij.ImagePlus;
+import ij.WindowManager;
+import net.imagej.Dataset;
+import net.imagej.ImageJ;
+import net.imglib2.RandomAccessibleInterval;
+
+
+@Plugin(type = Command.class, label = "CommandFromMacro", menuPath = "Plugins > StarDist > Other > CommandFromMacro")
+public class CommandFromMacro implements Command {
+
+    private static final List<ItemVisibility> SKIP_VISIBILITY = Arrays.asList(ItemVisibility.MESSAGE, ItemVisibility.INVISIBLE);
+
+    @Parameter
+    private String command;
+
+    @Parameter
+    private boolean process;
+
+    @Parameter
+    private String args;
+
+    // ---------
+
+    @Parameter
+    private UIService ui;
+
+    @Parameter
+    private CommandService cmd;
+
+    @Parameter
+    private LogService log;
+
+    // ---------
+
+    @Override
+    public void run() {
+
+        final CommandInfo info = cmd.getCommand(command);
+        if (info == null) {
+            log.warn(String.format("Command \"%s\" not found.", command));
+            return;
+        }
+
+        final Map<String,Object> params = new LinkedHashMap<>();
+        final List<String> outputs = new ArrayList<>();
+
+        Map<?,?> argsMap = new Gson().fromJson("{"+args+"}", Map.class);
+        // System.out.println(argsMap);
+
+        for (Object keyO : argsMap.keySet()) {
+            final String key = String.valueOf(keyO);
+            final String value = String.valueOf(argsMap.get(keyO));
+            ModuleItem<?> item = null;
+
+            item = info.getInput(key);
+            if (item != null) {
+                Class<?> clazz = item.getType();
+                if (clazz.isPrimitive())
+                    clazz = ClassUtils.primitiveToWrapper(clazz);
+                params.put(key, toParameter(value, clazz));
+            } else {
+                item = info.getOutput(key);
+                if (item != null) {
+                    outputs.add(key);
+                } else {
+                    log.warn(String.format("Ignoring argument \"%s\" since neither an input or output of this command.", key));
+                }
+            }
+        }
+
+        try {
+            final CommandModule result = cmd.run(command, process, params).get();
+            for (String name : outputs) {
+                final Object output = result.getOutput(name);
+                if (output != null) ui.show(output);
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    private Object toParameter(final String value, final Class<?> clazz) {
+        // some special classes (TODO: incomplete)
+        if (clazz == String.class)
+            return value;
+        if (clazz == File.class)
+            return new File(value);
+        // all typical number types and boolean are covered by this
+        if (clazz.getName().startsWith("java.lang.")) {
+            try {
+                return clazz.getDeclaredMethod("valueOf", String.class).invoke(null, value);
+            } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+                e.printStackTrace();
+            }
+        }
+        // ImagePlus and typical imagej2 image types (all that implement RAI)
+        if (clazz == ImagePlus.class || RandomAccessibleInterval.class.isAssignableFrom(clazz)) {
+            final ImagePlus imp = WindowManager.getImage(value);
+            if (imp == null)
+                log.error(String.format("Could not find input image with name/title \"%s\".", value));
+            return imp;
+        }
+        log.error(String.format("Cannot process arguments of class \"%s\".", clazz.getName()));
+        return null;
+    }
+
+
+    public static String getMacroString(final Command command, final CommandInfo info, final String... outputs) {
+        return getMacroString(command, info, false, outputs);
+    }
+
+    public static String getMacroString(final Command command, final CommandInfo info, final boolean process, final String... outputs) {
+        final Class<?> commandClass = command.getClass();
+        final Map<String,String> args = new LinkedHashMap<>();
+
+        for (final ModuleItem<?> item : info.inputs()) {
+            final String name = item.getName();
+            final Class<?> clazz = item.getType();
+            if (SKIP_VISIBILITY.contains(item.getVisibility()) || // skip items that shouldn't be recorded
+                Service.class.isAssignableFrom(clazz))            // skip all (injected) services
+                continue;
+            try {
+                final Field field = commandClass.getDeclaredField(name);
+                if (!field.isAccessible()) field.setAccessible(true);
+                final Object value = field.get(command);
+                // skip unassigned items (includes buttons)
+                if (value == null)
+                    continue;
+                if (Named.class.isAssignableFrom(clazz)) // ImgPlus and Dataset
+                    args.put(name, ((Named)value).getName());
+                else if (clazz == ImagePlus.class)
+                    args.put(name, ((ImagePlus)value).getTitle());
+                else
+                    args.put(name, String.valueOf(value));
+            } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }
+
+        for (final String name : outputs) {
+            if (info.getOutput(name) != null)
+                args.put(name, "");
+        }
+
+        String argsStr = new Gson().toJson(args);
+        argsStr = argsStr.substring(1, argsStr.length()-1); // remove curly braces
+        argsStr = StringEscapeUtils.escapeJava(argsStr);    // escape all quotes, etc.
+        return String.format("run(\"%s\", \"command=[%s], process=[%s], args=[%s]\");\n",
+                CommandFromMacro.class.getSimpleName(), commandClass.getName(), String.valueOf(process), argsStr);
+    }
+
+
+    public static void main(final String... args) throws Exception {
+
+        final ImageJ ij = new ImageJ();
+        ij.launch(args);
+
+        Dataset input = ij.scifio().datasetIO().open(StarDist2D.class.getClassLoader().getResource("yeast_crop.tif").getFile());
+        ij.ui().show(input);
+
+//        Dataset input2 = ij.scifio().datasetIO().open(StarDist2D.class.getClassLoader().getResource("yeast_timelapse.tif").getFile());
+//        ij.ui().show(input2);
+
+//        Recorder recorder = new Recorder();
+//        recorder.show();
+
+        IJ.run("CommandFromMacro", "args=[\"input\":\"yeast_crop.tif\", \"label\":\"\"], process=[false], command=[de.csbdresden.stardist.StarDist2D]");
+    }
+
+
+}

--- a/src/main/java/de/csbdresden/CommandFromMacro.java
+++ b/src/main/java/de/csbdresden/CommandFromMacro.java
@@ -37,7 +37,7 @@ import net.imagej.ImageJ;
 import net.imglib2.RandomAccessibleInterval;
 
 
-@Plugin(type = Command.class, label = "CommandFromMacro", menuPath = "Plugins > StarDist > Other > CommandFromMacro")
+@Plugin(type = Command.class, label = "Command From Macro", menuPath = "Plugins > StarDist > Other > Command From Macro")
 public class CommandFromMacro implements Command {
 
     private static final List<ItemVisibility> SKIP_VISIBILITY = Arrays.asList(ItemVisibility.MESSAGE, ItemVisibility.INVISIBLE);
@@ -46,10 +46,10 @@ public class CommandFromMacro implements Command {
     private String command;
 
     @Parameter
-    private boolean process;
+    private String args;
 
     @Parameter
-    private String args;
+    private boolean process;
 
     // ---------
 
@@ -157,11 +157,10 @@ public class CommandFromMacro implements Command {
         if (Recorder.getInstance() == null)
             return false;
         final String recorded = Recorder.getCommand();
-        // System.out.println("RECORDED: " + recorded);
         final CommandInfo info = commandService.getCommand(command.getClass());
         // only proceed if this command is being recorded
         final String name = info.getMenuPath().getLeaf().getName();
-        // final String cmdName = info.getLabel();
+        // System.out.printf("RECORDED: %s, COMMAND: %s\n", recorded, name);
         if (recorded==null || !recorded.equals(name))
             return false;
         // prevent automatic recording
@@ -237,8 +236,8 @@ public class CommandFromMacro implements Command {
         argsStr = sb.toString();
         
         final String execName = commandService.getCommand(CommandFromMacro.class).getMenuPath().getLeaf().getName();
-        return String.format("run(\"%s\", \"command=[%s], process=[%s], args=[%s]\");\n",
-                execName, commandClass.getName(), String.valueOf(process), argsStr);
+        return String.format("run(\"%s\", \"command=[%s], args=[%s], process=[%s]\");\n",
+                execName, commandClass.getName(), argsStr, String.valueOf(process));
     }
 
 

--- a/src/main/java/de/csbdresden/stardist/StarDist2D.java
+++ b/src/main/java/de/csbdresden/stardist/StarDist2D.java
@@ -28,6 +28,7 @@ import org.scijava.widget.Button;
 import org.scijava.widget.ChoiceWidget;
 import org.scijava.widget.NumberWidget;
 
+import de.csbdresden.CommandFromMacro;
 import ij.IJ;
 import ij.ImagePlus;
 import net.imagej.Dataset;
@@ -280,10 +281,6 @@ public class StarDist2D extends StarDist2DBase implements Command {
                     status.showProgress(1+t, (int)numFrames);
                 }
                 label = labelImageToDataset(outputType);
-                if (labelIsOutput(outputType))
-                    record("label");
-                else
-                    record();
 
             } else {
                 // note: the code below supports timelapse data too. differences to above:
@@ -302,19 +299,13 @@ public class StarDist2D extends StarDist2DBase implements Command {
                 if (showProbAndDist) {
                     prob = probDS;
                     dist = distDS;
-                    if (labelIsOutput(outputType))
-                        record("label","prob","dist");
-                    else
-                        record("prob","dist");
-                } else {
-                    if (labelIsOutput(outputType))
-                        record("label");
-                    else
-                        record();
                 }
 
                 final Future<CommandModule> futureNMS = command.run(StarDist2DNMS.class, false, paramsNMS);
-                label = (Dataset) futureNMS.get().getOutput("label");                
+                label = (Dataset) futureNMS.get().getOutput("label");
+                
+                // call at the end of the run() method
+                CommandFromMacro.record(this, this.command);                
             }
         } catch (InterruptedException | ExecutionException | IOException e) {
             e.printStackTrace();
@@ -383,6 +374,9 @@ public class StarDist2D extends StarDist2DBase implements Command {
 //        Dataset input = ij.scifio().datasetIO().open(StarDist2D.class.getClassLoader().getResource("yeast_timelapse.tif").getFile());
         Dataset input = ij.scifio().datasetIO().open(StarDist2D.class.getClassLoader().getResource("yeast_crop.tif").getFile());
         ij.ui().show(input);
+        
+//        Recorder recorder = new Recorder();
+//        recorder.show();
 
         final HashMap<String, Object> params = new HashMap<>();
         ij.command().run(StarDist2D.class, true, params);

--- a/src/main/java/de/csbdresden/stardist/StarDist2D.java
+++ b/src/main/java/de/csbdresden/stardist/StarDist2D.java
@@ -317,10 +317,10 @@ public class StarDist2D extends StarDist2DBase implements Command {
 
                 final Future<CommandModule> futureNMS = command.run(StarDist2DNMS.class, false, paramsNMS);
                 label = (Dataset) futureNMS.get().getOutput("label");
-                
-                // call at the end of the run() method
-                CommandFromMacro.record(this, this.command);                
             }
+            // call at the end of the run() method
+            CommandFromMacro.record(this, this.command);
+            
         } catch (InterruptedException | ExecutionException | IOException e) {
             e.printStackTrace();
         } finally {

--- a/src/main/java/de/csbdresden/stardist/StarDist2D.java
+++ b/src/main/java/de/csbdresden/stardist/StarDist2D.java
@@ -46,7 +46,7 @@ import net.imglib2.view.Views;
         @Menu(label = MenuConstants.PLUGINS_LABEL, weight = MenuConstants.PLUGINS_WEIGHT, mnemonic = MenuConstants.PLUGINS_MNEMONIC),
         @Menu(label = "StarDist"),
         @Menu(label = "StarDist 2D", weight = 1)
-}) 
+})
 public class StarDist2D extends StarDist2DBase implements Command {
 
     @Parameter(label="", visibility=ItemVisibility.MESSAGE, initializer="checkForCSBDeep")
@@ -280,6 +280,10 @@ public class StarDist2D extends StarDist2DBase implements Command {
                     status.showProgress(1+t, (int)numFrames);
                 }
                 label = labelImageToDataset(outputType);
+                if (labelIsOutput(outputType))
+                    record("label");
+                else
+                    record();
 
             } else {
                 // note: the code below supports timelapse data too. differences to above:
@@ -298,6 +302,15 @@ public class StarDist2D extends StarDist2DBase implements Command {
                 if (showProbAndDist) {
                     prob = probDS;
                     dist = distDS;
+                    if (labelIsOutput(outputType))
+                        record("label","prob","dist");
+                    else
+                        record("prob","dist");
+                } else {
+                    if (labelIsOutput(outputType))
+                        record("label");
+                    else
+                        record();
                 }
 
                 final Future<CommandModule> futureNMS = command.run(StarDist2DNMS.class, false, paramsNMS);

--- a/src/main/java/de/csbdresden/stardist/StarDist2DBase.java
+++ b/src/main/java/de/csbdresden/stardist/StarDist2DBase.java
@@ -183,7 +183,7 @@ public abstract class StarDist2DBase implements Command {
         // prevent automatic recording
         Recorder.setCommand(null);
         // record manually
-        Recorder.recordString(CommandFromMacro.getMacroCall(this, info, outputs));
+        Recorder.recordString(CommandFromMacro.getMacroString(this, info, outputs));
     }
     
 }

--- a/src/main/java/de/csbdresden/stardist/StarDist2DBase.java
+++ b/src/main/java/de/csbdresden/stardist/StarDist2DBase.java
@@ -4,7 +4,6 @@ import java.net.URL;
 import java.util.List;
 
 import org.scijava.app.StatusService;
-import org.scijava.command.Command;
 import org.scijava.command.CommandService;
 import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
@@ -24,7 +23,7 @@ import net.imagej.axis.AxisType;
 import net.imglib2.img.Img;
 import net.imglib2.img.display.imagej.ImageJFunctions;
 
-public abstract class StarDist2DBase implements Command {
+public abstract class StarDist2DBase {
     
     @Parameter
     protected LogService log;
@@ -145,7 +144,7 @@ public abstract class StarDist2DBase implements Command {
     abstract protected ImagePlus createLabelImage();
     
     protected Dataset labelImageToDataset(String outputType) {
-        if (labelIsOutput(outputType)) {
+        if (outputType.equals(Opt.OUTPUT_LABEL_IMAGE) || outputType.equals(Opt.OUTPUT_BOTH)) {
             if (labelCount > MAX_LABEL_ID) {
                 log.error(String.format("Found more than %d segments -> label image does contain some repetitive IDs.\n(\"%s\" output instead does not have this problem).", MAX_LABEL_ID, Opt.OUTPUT_ROI_MANAGER));
             }
@@ -157,9 +156,5 @@ public abstract class StarDist2DBase implements Command {
         } else {
             return null;
         }        
-    }
-    
-    protected boolean labelIsOutput(String outputType) {
-        return outputType.equals(Opt.OUTPUT_LABEL_IMAGE) || outputType.equals(Opt.OUTPUT_BOTH);        
     }
 }

--- a/src/main/java/de/csbdresden/stardist/StarDist2DBase.java
+++ b/src/main/java/de/csbdresden/stardist/StarDist2DBase.java
@@ -5,22 +5,16 @@ import java.util.List;
 
 import org.scijava.app.StatusService;
 import org.scijava.command.Command;
-import org.scijava.command.CommandInfo;
 import org.scijava.command.CommandService;
 import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.ui.DialogPrompt.MessageType;
-
-import de.csbdresden.CommandFromMacro;
-
 import org.scijava.ui.UIService;
 
-import ij.IJ;
 import ij.ImagePlus;
 import ij.gui.PointRoi;
 import ij.gui.PolygonRoi;
 import ij.gui.Roi;
-import ij.plugin.frame.Recorder;
 import ij.plugin.frame.RoiManager;
 import ij.process.ImageProcessor;
 import net.imagej.Dataset;
@@ -168,22 +162,4 @@ public abstract class StarDist2DBase implements Command {
     protected boolean labelIsOutput(String outputType) {
         return outputType.equals(Opt.OUTPUT_LABEL_IMAGE) || outputType.equals(Opt.OUTPUT_BOTH);        
     }
-    
-    protected void record(String... outputs) {
-        if (Recorder.getInstance() == null)
-            return;
-        final String recorded = Recorder.getCommand();
-        // System.out.println("RECORDED: " + recorded);
-        final CommandInfo info = command.getCommand(this.getClass());
-        // only proceed if this command is being recorded
-        final String cmdName = info.getMenuPath().getLeaf().getName();
-        // final String cmdName = info.getLabel();
-        if (recorded==null || !recorded.equals(cmdName))
-            return;
-        // prevent automatic recording
-        Recorder.setCommand(null);
-        // record manually
-        Recorder.recordString(CommandFromMacro.getMacroString(this, info, outputs));
-    }
-    
 }

--- a/src/main/java/de/csbdresden/stardist/StarDist2DNMS.java
+++ b/src/main/java/de/csbdresden/stardist/StarDist2DNMS.java
@@ -16,6 +16,7 @@ import org.scijava.widget.Button;
 import org.scijava.widget.ChoiceWidget;
 import org.scijava.widget.NumberWidget;
 
+import de.csbdresden.CommandFromMacro;
 import ij.IJ;
 import ij.ImagePlus;
 import net.imagej.Dataset;
@@ -113,10 +114,9 @@ public class StarDist2DNMS extends StarDist2DBase implements Command {
         }
         
         label = labelImageToDataset(outputType);
-        if (labelIsOutput(outputType))
-            record("label");
-        else
-            record();
+
+        // call at the end of the run() method
+        CommandFromMacro.record(this, this.command);
     }
     
 

--- a/src/main/java/de/csbdresden/stardist/StarDist2DNMS.java
+++ b/src/main/java/de/csbdresden/stardist/StarDist2DNMS.java
@@ -113,6 +113,10 @@ public class StarDist2DNMS extends StarDist2DBase implements Command {
         }
         
         label = labelImageToDataset(outputType);
+        if (labelIsOutput(outputType))
+            record("label");
+        else
+            record();
     }
     
 


### PR DESCRIPTION
As a reaction to PR #6 and reading @ctrueden's comment [here](https://github.com/imagej/imagej-legacy/pull/239#pullrequestreview-375238166), I've decided to make a generic SciJava Command `CommandFromMacro` that (potentially) allows to call any Command from IJ1 macro (without the need to press OK). The syntax is not ideal, but this is a workaround until the situation has been properly fixed.

Based on @haesleinhuepf's example in #6, I've added a custom macro recorder to take advantage of `CommandFromMacro` for the two StarDist Commands.

I'm not sure this is the way to go, but it seems to work and is (in my understanding) a fairly general solution that could be implemented/used by other plugins without much effort.